### PR TITLE
feat(kg): implement Phase 4 inference engine and API endpoint

### DIFF
--- a/agentic_neurodata_conversion/kg_service/api/v1/infer.py
+++ b/agentic_neurodata_conversion/kg_service/api/v1/infer.py
@@ -1,0 +1,124 @@
+"""Inference API Endpoint.
+
+POST /api/v1/infer - Infer metadata value based on historical observations
+"""
+
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+
+from agentic_neurodata_conversion.kg_service.config import get_settings
+from agentic_neurodata_conversion.kg_service.db.neo4j_connection import get_neo4j_connection
+from agentic_neurodata_conversion.kg_service.services.inference_engine import InferenceEngine
+
+logger = logging.getLogger(__name__)
+router = APIRouter(prefix="/api/v1", tags=["inference"])
+
+
+class InferRequest(BaseModel):
+    """Request model for inference endpoint.
+
+    Attributes:
+        field_path: Metadata field path (e.g., "subject.species")
+        source_file: Current file being processed
+        subject_id: Subject identifier to look up historical observations
+    """
+
+    field_path: str = Field(..., description="Metadata field path (e.g., 'subject.species')")
+    source_file: str = Field(..., description="Current file being processed")
+    subject_id: str = Field(..., description="Subject identifier for historical lookup")
+
+
+class InferResponse(BaseModel):
+    """Response model for inference endpoint.
+
+    Attributes:
+        has_suggestion: Whether a suggestion is available
+        suggested_value: Suggested value (null if no suggestion)
+        ontology_term_id: Ontology term ID (null if no suggestion)
+        confidence: Confidence score (0.8 for suggestions, 0.0 otherwise)
+        requires_confirmation: Whether user confirmation is required
+        reasoning: Explanation of inference result
+    """
+
+    has_suggestion: bool
+    suggested_value: str | None
+    ontology_term_id: str | None
+    confidence: float
+    requires_confirmation: bool
+    reasoning: str
+
+
+def get_inference_engine() -> InferenceEngine:
+    """Dependency to get InferenceEngine instance.
+
+    Creates a new InferenceEngine with Neo4j connection based on
+    current settings.
+
+    Returns:
+        InferenceEngine: Configured inference engine instance
+    """
+    settings = get_settings()
+    neo4j_conn = get_neo4j_connection(
+        uri=settings.neo4j_uri, user=settings.neo4j_user, password=settings.neo4j_password
+    )
+    return InferenceEngine(neo4j_conn)
+
+
+@router.post("/infer", response_model=InferResponse)
+async def infer_endpoint(request: InferRequest, engine: InferenceEngine = Depends(get_inference_engine)):
+    """Infer metadata value based on historical observations.
+
+    Analyzes historical observations for the same subject across
+    different files to suggest a value for the requested field.
+
+    Currently supports:
+    - subject.species: Requires ≥2 observations with 100% agreement
+
+    Args:
+        request: InferRequest with field_path, source_file, subject_id
+        engine: InferenceEngine instance (injected dependency)
+
+    Returns:
+        InferResponse with suggestion and reasoning
+
+    Raises:
+        HTTPException: 500 if inference fails
+
+    Example:
+        >>> POST /api/v1/infer
+        >>> {
+        >>>   "field_path": "subject.species",
+        >>>   "source_file": "subject_001_session_C.nwb",
+        >>>   "subject_id": "subject_001"
+        >>> }
+        >>>
+        >>> Response:
+        >>> {
+        >>>   "has_suggestion": true,
+        >>>   "suggested_value": "Mus musculus",
+        >>>   "ontology_term_id": "NCBITaxon:10090",
+        >>>   "confidence": 0.8,
+        >>>   "requires_confirmation": true,
+        >>>   "reasoning": "Based on 2 prior observations with 100% agreement"
+        >>> }
+    """
+    try:
+        logger.info(
+            f"Inference request: field_path={request.field_path}, "
+            f"subject_id={request.subject_id}, source_file={request.source_file}"
+        )
+
+        # Route to appropriate inference method based on field_path
+        result = await engine.infer_field(
+            field_path=request.field_path, subject_id=request.subject_id, target_file=request.source_file
+        )
+
+        logger.info(f"Inference result: has_suggestion={result['has_suggestion']}, confidence={result['confidence']}")
+
+        return InferResponse(**result)
+
+    except Exception as e:
+        logger.error(f"Inference error: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Inference failed: {str(e)}")

--- a/agentic_neurodata_conversion/kg_service/main.py
+++ b/agentic_neurodata_conversion/kg_service/main.py
@@ -9,7 +9,7 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-from agentic_neurodata_conversion.kg_service.api.v1 import normalize, observations, validate
+from agentic_neurodata_conversion.kg_service.api.v1 import infer, normalize, observations, validate
 from agentic_neurodata_conversion.kg_service.config import get_settings
 from agentic_neurodata_conversion.kg_service.db.neo4j_connection import get_neo4j_connection
 
@@ -57,6 +57,7 @@ app.add_middleware(
 app.include_router(normalize.router)
 app.include_router(validate.router)
 app.include_router(observations.router)
+app.include_router(infer.router)
 
 
 @app.get("/health")
@@ -78,5 +79,5 @@ async def root():
     return {
         "service": "NWB Knowledge Graph",
         "version": "1.0.0",
-        "endpoints": ["/api/v1/normalize", "/api/v1/validate", "/api/v1/observations", "/health"],
+        "endpoints": ["/api/v1/normalize", "/api/v1/validate", "/api/v1/observations", "/api/v1/infer", "/health"],
     }

--- a/agentic_neurodata_conversion/kg_service/services/inference_engine.py
+++ b/agentic_neurodata_conversion/kg_service/services/inference_engine.py
@@ -1,0 +1,169 @@
+"""Inference Engine for Knowledge Graph.
+
+Simple inference engine implementing species consistency rule:
+- Requires ≥2 evidence observations from same subject
+- Requires 100% agreement across all observations
+- Returns confidence 0.8 for suggested species
+- All suggestions require user confirmation
+"""
+
+import logging
+from typing import Any
+
+from agentic_neurodata_conversion.kg_service.db.neo4j_connection import AsyncNeo4jConnection
+
+logger = logging.getLogger(__name__)
+
+
+class InferenceEngine:
+    """Simple inference engine for species consistency.
+
+    Implements a single rule: infer species for a subject based on
+    their historical observations across multiple files.
+
+    Requirements:
+    - Minimum 2 observations required
+    - 100% agreement required (no conflicts)
+    - Returns confidence 0.8
+    - Always requires user confirmation
+    """
+
+    def __init__(self, neo4j_conn: AsyncNeo4jConnection):
+        """Initialize inference engine.
+
+        Args:
+            neo4j_conn: AsyncNeo4jConnection instance for database queries
+        """
+        self.neo4j_conn = neo4j_conn
+
+    async def infer_species(self, subject_id: str, target_file: str) -> dict[str, Any]:
+        """Infer species for subject based on historical observations.
+
+        Analyzes all active observations for the given subject across
+        different files (excluding the target file) and suggests a species
+        if there is sufficient consistent evidence.
+
+        Args:
+            subject_id: Subject identifier (e.g., "subject_001")
+            target_file: Current file being processed (excluded from evidence)
+
+        Returns:
+            Dict containing:
+            - has_suggestion (bool): Whether a suggestion is available
+            - suggested_value (str|None): Suggested species label
+            - ontology_term_id (str|None): Ontology term ID
+            - confidence (float): Confidence score (0.8 if suggestion, 0.0 otherwise)
+            - requires_confirmation (bool): Always True for suggestions
+            - reasoning (str): Explanation of inference result
+
+        Example:
+            >>> engine = InferenceEngine(neo4j_conn)
+            >>> result = await engine.infer_species("subject_001", "file_C.nwb")
+            >>> print(result)
+            {
+                "has_suggestion": True,
+                "suggested_value": "Mus musculus",
+                "ontology_term_id": "NCBITaxon:10090",
+                "confidence": 0.8,
+                "requires_confirmation": True,
+                "reasoning": "Based on 2 prior observations with 100% agreement"
+            }
+        """
+        logger.info(f"Inferring species for subject_id={subject_id}, target_file={target_file}")
+
+        # Query to find species with sufficient evidence
+        # Requirements:
+        # 1. Get all observations for this subject (excluding target file)
+        # 2. Group by normalized_value, count occurrences
+        # 3. Check if top species has ≥2 observations
+        # 4. Verify 100% agreement (only one unique species exists)
+        query = """
+        MATCH (obs:Observation {field_path: 'subject.species'})
+        WHERE obs.source_file CONTAINS $subject_id
+          AND obs.source_file <> $target_file
+          AND obs.is_active = true
+        WITH obs.normalized_value AS species, count(*) AS evidence_count
+        ORDER BY evidence_count DESC
+        LIMIT 1
+        WITH species, evidence_count
+        WHERE evidence_count >= 2
+        MATCH (obs2:Observation {field_path: 'subject.species'})
+        WHERE obs2.source_file CONTAINS $subject_id
+          AND obs2.source_file <> $target_file
+          AND obs2.is_active = true
+        WITH species, evidence_count, collect(DISTINCT obs2.normalized_value) AS all_species
+        WHERE size(all_species) = 1
+        MATCH (term:OntologyTerm)
+        WHERE term.label = species
+        RETURN species AS suggested_value,
+               term.term_id AS ontology_term_id,
+               evidence_count
+        """
+
+        params = {"subject_id": subject_id, "target_file": target_file}
+
+        try:
+            results = await self.neo4j_conn.execute_read(query, params)
+
+            if results and len(results) > 0:
+                result = results[0]
+                evidence_count = result["evidence_count"]
+
+                logger.info(
+                    f"Inference successful: {result['suggested_value']} "
+                    f"(evidence_count={evidence_count}, confidence=0.8)"
+                )
+
+                return {
+                    "has_suggestion": True,
+                    "suggested_value": result["suggested_value"],
+                    "ontology_term_id": result["ontology_term_id"],
+                    "confidence": 0.8,
+                    "requires_confirmation": True,
+                    "reasoning": f"Based on {evidence_count} prior observations with 100% agreement",
+                }
+
+            logger.info("Inference failed: insufficient evidence or conflicting observations")
+
+            return {
+                "has_suggestion": False,
+                "suggested_value": None,
+                "ontology_term_id": None,
+                "confidence": 0.0,
+                "requires_confirmation": False,
+                "reasoning": "Insufficient evidence (need ≥2 observations with 100% agreement)",
+            }
+
+        except Exception as e:
+            logger.error(f"Inference error: {e}")
+            raise
+
+    async def infer_field(self, field_path: str, subject_id: str, target_file: str) -> dict[str, Any]:
+        """Infer value for any field (routing method).
+
+        Currently only supports subject.species. Can be extended
+        for other fields in the future.
+
+        Args:
+            field_path: Field to infer (e.g., "subject.species")
+            subject_id: Subject identifier
+            target_file: Current file being processed
+
+        Returns:
+            Dict with inference result or unsupported field message
+
+        Example:
+            >>> result = await engine.infer_field("subject.species", "subject_001", "file.nwb")
+        """
+        if field_path == "subject.species":
+            return await self.infer_species(subject_id=subject_id, target_file=target_file)
+        else:
+            logger.warning(f"Inference not supported for field_path={field_path}")
+            return {
+                "has_suggestion": False,
+                "suggested_value": None,
+                "ontology_term_id": None,
+                "confidence": 0.0,
+                "requires_confirmation": False,
+                "reasoning": f"Inference not supported for {field_path}",
+            }

--- a/tests/kg_service/api/v1/test_infer.py
+++ b/tests/kg_service/api/v1/test_infer.py
@@ -1,0 +1,328 @@
+"""API Tests for Inference Endpoint.
+
+Tests for kg_service/api/v1/infer.py endpoint.
+"""
+
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+from fastapi import HTTPException
+
+from agentic_neurodata_conversion.kg_service.api.v1.infer import InferRequest, InferResponse, infer_endpoint
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_infer_endpoint_with_suggestion():
+    """Test inference endpoint with valid suggestion."""
+    mock_engine = Mock()
+    mock_engine.infer_field = AsyncMock(
+        return_value={
+            "has_suggestion": True,
+            "suggested_value": "Mus musculus",
+            "ontology_term_id": "NCBITaxon:10090",
+            "confidence": 0.8,
+            "requires_confirmation": True,
+            "reasoning": "Based on 2 prior observations with 100% agreement",
+        }
+    )
+
+    request = InferRequest(
+        field_path="subject.species", source_file="subject_001_session_C.nwb", subject_id="subject_001"
+    )
+
+    response = await infer_endpoint(request, mock_engine)
+
+    assert isinstance(response, InferResponse)
+    assert response.has_suggestion is True
+    assert response.suggested_value == "Mus musculus"
+    assert response.ontology_term_id == "NCBITaxon:10090"
+    assert response.confidence == 0.8
+    assert response.requires_confirmation is True
+    assert "2 prior observations" in response.reasoning
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_infer_endpoint_no_suggestion_insufficient_evidence():
+    """Test inference endpoint with insufficient evidence."""
+    mock_engine = Mock()
+    mock_engine.infer_field = AsyncMock(
+        return_value={
+            "has_suggestion": False,
+            "suggested_value": None,
+            "ontology_term_id": None,
+            "confidence": 0.0,
+            "requires_confirmation": False,
+            "reasoning": "Insufficient evidence (need ≥2 observations with 100% agreement)",
+        }
+    )
+
+    request = InferRequest(field_path="subject.species", source_file="new_file.nwb", subject_id="subject_new")
+
+    response = await infer_endpoint(request, mock_engine)
+
+    assert response.has_suggestion is False
+    assert response.suggested_value is None
+    assert response.ontology_term_id is None
+    assert response.confidence == 0.0
+    assert response.requires_confirmation is False
+    assert "Insufficient evidence" in response.reasoning
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_infer_endpoint_unsupported_field():
+    """Test inference endpoint with unsupported field path."""
+    mock_engine = Mock()
+    mock_engine.infer_field = AsyncMock(
+        return_value={
+            "has_suggestion": False,
+            "suggested_value": None,
+            "ontology_term_id": None,
+            "confidence": 0.0,
+            "requires_confirmation": False,
+            "reasoning": "Inference not supported for subject.age",
+        }
+    )
+
+    request = InferRequest(field_path="subject.age", source_file="test.nwb", subject_id="subject_001")
+
+    response = await infer_endpoint(request, mock_engine)
+
+    assert response.has_suggestion is False
+    assert response.confidence == 0.0
+    assert "not supported" in response.reasoning
+    assert "subject.age" in response.reasoning
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_infer_endpoint_three_observations():
+    """Test inference with more than minimum observations."""
+    mock_engine = Mock()
+    mock_engine.infer_field = AsyncMock(
+        return_value={
+            "has_suggestion": True,
+            "suggested_value": "Rattus norvegicus",
+            "ontology_term_id": "NCBITaxon:10116",
+            "confidence": 0.8,
+            "requires_confirmation": True,
+            "reasoning": "Based on 3 prior observations with 100% agreement",
+        }
+    )
+
+    request = InferRequest(field_path="subject.species", source_file="session_new.nwb", subject_id="subject_002")
+
+    response = await infer_endpoint(request, mock_engine)
+
+    assert response.has_suggestion is True
+    assert response.suggested_value == "Rattus norvegicus"
+    assert response.confidence == 0.8
+    assert "3 prior observations" in response.reasoning
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_infer_endpoint_empty_subject_id():
+    """Test inference with empty subject_id."""
+    mock_engine = Mock()
+    mock_engine.infer_field = AsyncMock(
+        return_value={
+            "has_suggestion": False,
+            "suggested_value": None,
+            "ontology_term_id": None,
+            "confidence": 0.0,
+            "requires_confirmation": False,
+            "reasoning": "Insufficient evidence (need ≥2 observations with 100% agreement)",
+        }
+    )
+
+    request = InferRequest(field_path="subject.species", source_file="test.nwb", subject_id="")
+
+    response = await infer_endpoint(request, mock_engine)
+
+    assert response.has_suggestion is False
+    # Verify engine was still called with empty subject_id
+    mock_engine.infer_field.assert_called_once_with(field_path="subject.species", subject_id="", target_file="test.nwb")
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_infer_endpoint_error_handling():
+    """Test inference endpoint error handling."""
+    mock_engine = Mock()
+    mock_engine.infer_field = AsyncMock(side_effect=Exception("Database connection error"))
+
+    request = InferRequest(field_path="subject.species", source_file="test.nwb", subject_id="subject_001")
+
+    with pytest.raises(HTTPException) as exc_info:
+        await infer_endpoint(request, mock_engine)
+
+    assert exc_info.value.status_code == 500
+    assert "Inference failed" in str(exc_info.value.detail)
+    assert "Database connection error" in str(exc_info.value.detail)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_infer_endpoint_calls_engine_with_correct_params():
+    """Test that endpoint calls inference engine with correct parameters."""
+    mock_engine = Mock()
+    mock_engine.infer_field = AsyncMock(
+        return_value={
+            "has_suggestion": True,
+            "suggested_value": "Homo sapiens",
+            "ontology_term_id": "NCBITaxon:9606",
+            "confidence": 0.8,
+            "requires_confirmation": True,
+            "reasoning": "Based on 2 prior observations with 100% agreement",
+        }
+    )
+
+    request = InferRequest(
+        field_path="subject.species", source_file="subject_001_session_C.nwb", subject_id="subject_001"
+    )
+
+    await infer_endpoint(request, mock_engine)
+
+    # Verify engine was called with correct parameters
+    mock_engine.infer_field.assert_called_once_with(
+        field_path="subject.species", subject_id="subject_001", target_file="subject_001_session_C.nwb"
+    )
+
+
+@pytest.mark.unit
+def test_infer_request_validation():
+    """Test InferRequest model validation."""
+    # Valid request
+    request = InferRequest(field_path="subject.species", source_file="test.nwb", subject_id="subject_001")
+    assert request.field_path == "subject.species"
+    assert request.source_file == "test.nwb"
+    assert request.subject_id == "subject_001"
+
+    # Test with different field paths
+    request2 = InferRequest(field_path="subject.age", source_file="file.nwb", subject_id="subject_002")
+    assert request2.field_path == "subject.age"
+
+
+@pytest.mark.unit
+def test_infer_response_model_with_suggestion():
+    """Test InferResponse model with suggestion."""
+    response = InferResponse(
+        has_suggestion=True,
+        suggested_value="Mus musculus",
+        ontology_term_id="NCBITaxon:10090",
+        confidence=0.8,
+        requires_confirmation=True,
+        reasoning="Based on 2 prior observations with 100% agreement",
+    )
+
+    assert response.has_suggestion is True
+    assert response.suggested_value == "Mus musculus"
+    assert response.ontology_term_id == "NCBITaxon:10090"
+    assert response.confidence == 0.8
+    assert response.requires_confirmation is True
+
+
+@pytest.mark.unit
+def test_infer_response_model_no_suggestion():
+    """Test InferResponse model without suggestion."""
+    response = InferResponse(
+        has_suggestion=False,
+        suggested_value=None,
+        ontology_term_id=None,
+        confidence=0.0,
+        requires_confirmation=False,
+        reasoning="Insufficient evidence",
+    )
+
+    assert response.has_suggestion is False
+    assert response.suggested_value is None
+    assert response.ontology_term_id is None
+    assert response.confidence == 0.0
+    assert response.requires_confirmation is False
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_infer_endpoint_human_species():
+    """Test inference with human species."""
+    mock_engine = Mock()
+    mock_engine.infer_field = AsyncMock(
+        return_value={
+            "has_suggestion": True,
+            "suggested_value": "Homo sapiens",
+            "ontology_term_id": "NCBITaxon:9606",
+            "confidence": 0.8,
+            "requires_confirmation": True,
+            "reasoning": "Based on 4 prior observations with 100% agreement",
+        }
+    )
+
+    request = InferRequest(field_path="subject.species", source_file="clinical_data.nwb", subject_id="patient_123")
+
+    response = await infer_endpoint(request, mock_engine)
+
+    assert response.suggested_value == "Homo sapiens"
+    assert response.ontology_term_id == "NCBITaxon:9606"
+    assert response.has_suggestion is True
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_infer_endpoint_special_characters_in_file_name():
+    """Test inference with special characters in file name."""
+    mock_engine = Mock()
+    mock_engine.infer_field = AsyncMock(
+        return_value={
+            "has_suggestion": True,
+            "suggested_value": "Mus musculus",
+            "ontology_term_id": "NCBITaxon:10090",
+            "confidence": 0.8,
+            "requires_confirmation": True,
+            "reasoning": "Based on 2 prior observations with 100% agreement",
+        }
+    )
+
+    request = InferRequest(
+        field_path="subject.species", source_file="subject_001_session-2023-12-01_run#3.nwb", subject_id="subject_001"
+    )
+
+    response = await infer_endpoint(request, mock_engine)
+
+    assert response.has_suggestion is True
+    # Verify file name was passed correctly
+    mock_engine.infer_field.assert_called_once()
+    call_args = mock_engine.infer_field.call_args
+    assert call_args.kwargs["target_file"] == "subject_001_session-2023-12-01_run#3.nwb"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_infer_endpoint_long_reasoning():
+    """Test inference with long reasoning text."""
+    mock_engine = Mock()
+    long_reasoning = (
+        "Based on 5 prior observations with 100% agreement. "
+        "All observations from sessions A, B, C, D, and E consistently "
+        "identified the species as Mus musculus (house mouse). "
+        "High confidence in suggestion."
+    )
+    mock_engine.infer_field = AsyncMock(
+        return_value={
+            "has_suggestion": True,
+            "suggested_value": "Mus musculus",
+            "ontology_term_id": "NCBITaxon:10090",
+            "confidence": 0.8,
+            "requires_confirmation": True,
+            "reasoning": long_reasoning,
+        }
+    )
+
+    request = InferRequest(field_path="subject.species", source_file="session_F.nwb", subject_id="subject_001")
+
+    response = await infer_endpoint(request, mock_engine)
+
+    assert response.reasoning == long_reasoning
+    assert len(response.reasoning) > 100

--- a/tests/kg_service/services/test_inference_engine.py
+++ b/tests/kg_service/services/test_inference_engine.py
@@ -1,0 +1,320 @@
+"""Unit tests for InferenceEngine.
+
+Tests the species consistency inference rule with various evidence scenarios.
+"""
+
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from agentic_neurodata_conversion.kg_service.services.inference_engine import InferenceEngine
+
+
+@pytest.fixture
+def mock_neo4j_connection():
+    """Mock Neo4j connection for testing."""
+    conn = Mock()
+    conn.execute_read = AsyncMock()
+    return conn
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_infer_species_sufficient_evidence(mock_neo4j_connection):
+    """Test inference with ≥2 observations and 100% agreement.
+
+    Should return:
+    - has_suggestion: True
+    - confidence: 0.8
+    - suggested_value: species label
+    - ontology_term_id: NCBITaxon ID
+    """
+    # Mock: 2 observations, all agree on Mus musculus
+    mock_neo4j_connection.execute_read = AsyncMock(
+        return_value=[
+            {
+                "suggested_value": "Mus musculus",
+                "ontology_term_id": "NCBITaxon:10090",
+                "evidence_count": 2,
+            }
+        ]
+    )
+
+    engine = InferenceEngine(mock_neo4j_connection)
+
+    result = await engine.infer_species(subject_id="subject_001", target_file="session_C.nwb")
+
+    assert result["has_suggestion"] is True
+    assert result["suggested_value"] == "Mus musculus"
+    assert result["ontology_term_id"] == "NCBITaxon:10090"
+    assert result["confidence"] == 0.8
+    assert result["requires_confirmation"] is True
+    assert "2 prior observations" in result["reasoning"]
+    assert "100% agreement" in result["reasoning"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_infer_species_three_observations(mock_neo4j_connection):
+    """Test inference with 3 observations (more than minimum).
+
+    Should still return confidence 0.8 with 3 observations.
+    """
+    mock_neo4j_connection.execute_read = AsyncMock(
+        return_value=[
+            {
+                "suggested_value": "Rattus norvegicus",
+                "ontology_term_id": "NCBITaxon:10116",
+                "evidence_count": 3,
+            }
+        ]
+    )
+
+    engine = InferenceEngine(mock_neo4j_connection)
+
+    result = await engine.infer_species(subject_id="subject_002", target_file="new_session.nwb")
+
+    assert result["has_suggestion"] is True
+    assert result["confidence"] == 0.8
+    assert "3 prior observations" in result["reasoning"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_infer_species_insufficient_evidence_single_observation(mock_neo4j_connection):
+    """Test inference with only 1 observation (insufficient).
+
+    Should return:
+    - has_suggestion: False
+    - confidence: 0.0
+    - reasoning explains insufficient evidence
+    """
+    # Mock: Only 1 observation (needs ≥2)
+    mock_neo4j_connection.execute_read = AsyncMock(return_value=[])
+
+    engine = InferenceEngine(mock_neo4j_connection)
+
+    result = await engine.infer_species(subject_id="subject_003", target_file="test.nwb")
+
+    assert result["has_suggestion"] is False
+    assert result["suggested_value"] is None
+    assert result["ontology_term_id"] is None
+    assert result["confidence"] == 0.0
+    assert result["requires_confirmation"] is False
+    assert "Insufficient evidence" in result["reasoning"]
+    assert "≥2 observations" in result["reasoning"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_infer_species_no_observations(mock_neo4j_connection):
+    """Test inference with no observations at all.
+
+    Should return no suggestion.
+    """
+    mock_neo4j_connection.execute_read = AsyncMock(return_value=[])
+
+    engine = InferenceEngine(mock_neo4j_connection)
+
+    result = await engine.infer_species(subject_id="subject_new", target_file="first_session.nwb")
+
+    assert result["has_suggestion"] is False
+    assert result["confidence"] == 0.0
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_infer_species_conflicting_evidence(mock_neo4j_connection):
+    """Test inference with conflicting observations (not 100% agreement).
+
+    If observations disagree, Cypher query returns no results
+    because WHERE size(all_species) = 1 fails.
+
+    Should return no suggestion.
+    """
+    # Mock: Conflicting evidence - query returns empty because of disagreement
+    mock_neo4j_connection.execute_read = AsyncMock(return_value=[])
+
+    engine = InferenceEngine(mock_neo4j_connection)
+
+    result = await engine.infer_species(subject_id="subject_conflicted", target_file="session_D.nwb")
+
+    assert result["has_suggestion"] is False
+    assert result["confidence"] == 0.0
+    assert "Insufficient evidence" in result["reasoning"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_infer_species_excludes_target_file(mock_neo4j_connection):
+    """Test that inference excludes observations from target file.
+
+    The target_file parameter should be passed to query to exclude
+    observations from the current file being processed.
+    """
+    mock_neo4j_connection.execute_read = AsyncMock(
+        return_value=[
+            {
+                "suggested_value": "Homo sapiens",
+                "ontology_term_id": "NCBITaxon:9606",
+                "evidence_count": 2,
+            }
+        ]
+    )
+
+    engine = InferenceEngine(mock_neo4j_connection)
+
+    target_file = "subject_001_session_C.nwb"
+    result = await engine.infer_species(subject_id="subject_001", target_file=target_file)
+
+    # Verify execute_read was called with correct parameters
+    mock_neo4j_connection.execute_read.assert_called_once()
+    call_args = mock_neo4j_connection.execute_read.call_args
+    params = call_args[0][1]  # Second argument is params dict
+
+    assert params["target_file"] == target_file
+    assert params["subject_id"] == "subject_001"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_infer_field_species(mock_neo4j_connection):
+    """Test infer_field routing to infer_species."""
+    mock_neo4j_connection.execute_read = AsyncMock(
+        return_value=[
+            {
+                "suggested_value": "Mus musculus",
+                "ontology_term_id": "NCBITaxon:10090",
+                "evidence_count": 2,
+            }
+        ]
+    )
+
+    engine = InferenceEngine(mock_neo4j_connection)
+
+    result = await engine.infer_field(field_path="subject.species", subject_id="subject_001", target_file="test.nwb")
+
+    assert result["has_suggestion"] is True
+    assert result["suggested_value"] == "Mus musculus"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_infer_field_unsupported_field(mock_neo4j_connection):
+    """Test infer_field with unsupported field path.
+
+    Should return no suggestion with appropriate reasoning.
+    """
+    engine = InferenceEngine(mock_neo4j_connection)
+
+    result = await engine.infer_field(field_path="subject.age", subject_id="subject_001", target_file="test.nwb")
+
+    assert result["has_suggestion"] is False
+    assert result["confidence"] == 0.0
+    assert "not supported" in result["reasoning"]
+    assert "subject.age" in result["reasoning"]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_infer_species_database_error(mock_neo4j_connection):
+    """Test inference when database query raises exception.
+
+    Should propagate the exception to caller.
+    """
+    mock_neo4j_connection.execute_read = AsyncMock(side_effect=Exception("Database connection error"))
+
+    engine = InferenceEngine(mock_neo4j_connection)
+
+    with pytest.raises(Exception, match="Database connection error"):
+        await engine.infer_species(subject_id="subject_001", target_file="test.nwb")
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_infer_species_query_structure(mock_neo4j_connection):
+    """Test that Cypher query has correct structure.
+
+    Verifies:
+    - Query filters by field_path='subject.species'
+    - Query checks is_active=true
+    - Query requires evidence_count >= 2
+    - Query requires size(all_species) = 1 (100% agreement)
+    - Query joins with OntologyTerm
+    """
+    mock_neo4j_connection.execute_read = AsyncMock(
+        return_value=[
+            {
+                "suggested_value": "Mus musculus",
+                "ontology_term_id": "NCBITaxon:10090",
+                "evidence_count": 2,
+            }
+        ]
+    )
+
+    engine = InferenceEngine(mock_neo4j_connection)
+
+    await engine.infer_species(subject_id="subject_001", target_file="target.nwb")
+
+    # Get the query that was executed
+    call_args = mock_neo4j_connection.execute_read.call_args
+    query = call_args[0][0]  # First argument is query string
+
+    # Verify key requirements in query
+    assert "field_path: 'subject.species'" in query
+    assert "is_active = true" in query
+    assert "evidence_count >= 2" in query
+    assert "size(all_species) = 1" in query
+    assert "MATCH (term:OntologyTerm)" in query
+    assert "WHERE obs.source_file CONTAINS $subject_id" in query
+    assert "AND obs.source_file <> $target_file" in query
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_infer_species_returns_all_required_fields(mock_neo4j_connection):
+    """Test that inference result contains all required fields."""
+    mock_neo4j_connection.execute_read = AsyncMock(
+        return_value=[
+            {
+                "suggested_value": "Mus musculus",
+                "ontology_term_id": "NCBITaxon:10090",
+                "evidence_count": 2,
+            }
+        ]
+    )
+
+    engine = InferenceEngine(mock_neo4j_connection)
+
+    result = await engine.infer_species(subject_id="subject_001", target_file="test.nwb")
+
+    # Verify all required fields are present
+    required_fields = [
+        "has_suggestion",
+        "suggested_value",
+        "ontology_term_id",
+        "confidence",
+        "requires_confirmation",
+        "reasoning",
+    ]
+
+    for field in required_fields:
+        assert field in result, f"Missing required field: {field}"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_infer_species_empty_subject_id(mock_neo4j_connection):
+    """Test inference with empty subject_id.
+
+    Should query database but likely return no results.
+    """
+    mock_neo4j_connection.execute_read = AsyncMock(return_value=[])
+
+    engine = InferenceEngine(mock_neo4j_connection)
+
+    result = await engine.infer_species(subject_id="", target_file="test.nwb")
+
+    assert result["has_suggestion"] is False
+    # Verify query was still executed with empty subject_id
+    mock_neo4j_connection.execute_read.assert_called_once()

--- a/tests/kg_service/test_phase4_integration.py
+++ b/tests/kg_service/test_phase4_integration.py
@@ -1,0 +1,577 @@
+"""Phase 4 Integration Tests.
+
+End-to-end tests for Phase 4 species inference functionality.
+Tests the full inference workflow with Neo4j backend.
+"""
+
+import os
+
+import httpx
+import pytest
+
+
+@pytest.fixture
+async def kg_service_client():
+    """Fixture for async HTTP client with FastAPI app."""
+    # Skip if NEO4J_PASSWORD not set (e.g., in CI)
+    password = os.getenv("NEO4J_PASSWORD")
+    if not password:
+        pytest.skip("NEO4J_PASSWORD not set - integration tests require local Neo4j instance")
+
+    from agentic_neurodata_conversion.kg_service.config import get_settings
+    from agentic_neurodata_conversion.kg_service.db.neo4j_connection import get_neo4j_connection, reset_neo4j_connection
+    from agentic_neurodata_conversion.kg_service.main import app
+
+    # Reset connection to avoid singleton issues
+    reset_neo4j_connection()
+
+    # Get Neo4j connection and connect
+    settings = get_settings()
+    neo4j_conn = get_neo4j_connection(
+        uri=settings.neo4j_uri, user=settings.neo4j_user, password=settings.neo4j_password
+    )
+
+    # Try to connect, skip if Neo4j isn't running
+    try:
+        await neo4j_conn.connect()
+    except Exception as e:
+        pytest.skip(f"Neo4j not accessible: {e}")
+
+    # Create HTTP client with ASGI transport
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        yield client
+
+    # Cleanup
+    await neo4j_conn.close()
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_infer_species_sufficient_evidence(kg_service_client):
+    """Test inference with ≥2 observations with 100% agreement.
+
+    Workflow:
+    1. Store 2 observations for subject_phase4_001 with species "Mus musculus"
+    2. Call /infer for same subject with different file
+    3. Verify suggestion is returned with confidence 0.8
+    """
+    subject_id = "subject_phase4_001"
+
+    # Store first observation
+    response1 = await kg_service_client.post(
+        "/api/v1/observations",
+        json={
+            "field_path": "subject.species",
+            "raw_value": "Mus musculus",
+            "normalized_value": "Mus musculus",
+            "ontology_term_id": "NCBITaxon:10090",
+            "source_type": "user",
+            "source_file": f"{subject_id}_session_A.nwb",
+            "confidence": 1.0,
+        },
+    )
+    assert response1.status_code == 200
+
+    # Store second observation
+    response2 = await kg_service_client.post(
+        "/api/v1/observations",
+        json={
+            "field_path": "subject.species",
+            "raw_value": "Mus musculus",
+            "normalized_value": "Mus musculus",
+            "ontology_term_id": "NCBITaxon:10090",
+            "source_type": "user",
+            "source_file": f"{subject_id}_session_B.nwb",
+            "confidence": 1.0,
+        },
+    )
+    assert response2.status_code == 200
+
+    # Call inference endpoint for new session
+    infer_response = await kg_service_client.post(
+        "/api/v1/infer",
+        json={
+            "field_path": "subject.species",
+            "source_file": f"{subject_id}_session_C.nwb",
+            "subject_id": subject_id,
+        },
+    )
+
+    assert infer_response.status_code == 200
+    data = infer_response.json()
+
+    assert data["has_suggestion"] is True
+    assert data["suggested_value"] == "Mus musculus"
+    assert data["ontology_term_id"] == "NCBITaxon:10090"
+    assert data["confidence"] == 0.8
+    assert data["requires_confirmation"] is True
+    assert "2 prior observations" in data["reasoning"]
+    assert "100% agreement" in data["reasoning"]
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_infer_species_insufficient_evidence_single_observation(kg_service_client):
+    """Test inference with only 1 observation (insufficient).
+
+    Should return no suggestion.
+    """
+    subject_id = "subject_phase4_002"
+
+    # Store only one observation
+    response1 = await kg_service_client.post(
+        "/api/v1/observations",
+        json={
+            "field_path": "subject.species",
+            "raw_value": "Rattus norvegicus",
+            "normalized_value": "Rattus norvegicus",
+            "ontology_term_id": "NCBITaxon:10116",
+            "source_type": "user",
+            "source_file": f"{subject_id}_session_A.nwb",
+            "confidence": 1.0,
+        },
+    )
+    assert response1.status_code == 200
+
+    # Call inference endpoint
+    infer_response = await kg_service_client.post(
+        "/api/v1/infer",
+        json={
+            "field_path": "subject.species",
+            "source_file": f"{subject_id}_session_B.nwb",
+            "subject_id": subject_id,
+        },
+    )
+
+    assert infer_response.status_code == 200
+    data = infer_response.json()
+
+    assert data["has_suggestion"] is False
+    assert data["suggested_value"] is None
+    assert data["ontology_term_id"] is None
+    assert data["confidence"] == 0.0
+    assert data["requires_confirmation"] is False
+    assert "Insufficient evidence" in data["reasoning"]
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_infer_species_no_observations(kg_service_client):
+    """Test inference for subject with no historical observations.
+
+    Should return no suggestion.
+    """
+    subject_id = "subject_phase4_never_seen"
+
+    # Call inference without storing any observations
+    infer_response = await kg_service_client.post(
+        "/api/v1/infer",
+        json={
+            "field_path": "subject.species",
+            "source_file": f"{subject_id}_first_session.nwb",
+            "subject_id": subject_id,
+        },
+    )
+
+    assert infer_response.status_code == 200
+    data = infer_response.json()
+
+    assert data["has_suggestion"] is False
+    assert data["confidence"] == 0.0
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_infer_species_three_observations(kg_service_client):
+    """Test inference with 3 observations (more than minimum).
+
+    Should still return confidence 0.8.
+    """
+    subject_id = "subject_phase4_003"
+
+    # Store three observations
+    for session in ["A", "B", "C"]:
+        response = await kg_service_client.post(
+            "/api/v1/observations",
+            json={
+                "field_path": "subject.species",
+                "raw_value": "Homo sapiens",
+                "normalized_value": "Homo sapiens",
+                "ontology_term_id": "NCBITaxon:9606",
+                "source_type": "user",
+                "source_file": f"{subject_id}_session_{session}.nwb",
+                "confidence": 1.0,
+            },
+        )
+        assert response.status_code == 200
+
+    # Call inference for new session
+    infer_response = await kg_service_client.post(
+        "/api/v1/infer",
+        json={
+            "field_path": "subject.species",
+            "source_file": f"{subject_id}_session_D.nwb",
+            "subject_id": subject_id,
+        },
+    )
+
+    assert infer_response.status_code == 200
+    data = infer_response.json()
+
+    assert data["has_suggestion"] is True
+    assert data["suggested_value"] == "Homo sapiens"
+    assert data["confidence"] == 0.8
+    assert "3 prior observations" in data["reasoning"]
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_infer_species_conflicting_observations(kg_service_client):
+    """Test inference with conflicting observations (not 100% agreement).
+
+    Should return no suggestion.
+    """
+    subject_id = "subject_phase4_004"
+
+    # Store observation for Mus musculus
+    response1 = await kg_service_client.post(
+        "/api/v1/observations",
+        json={
+            "field_path": "subject.species",
+            "raw_value": "Mus musculus",
+            "normalized_value": "Mus musculus",
+            "ontology_term_id": "NCBITaxon:10090",
+            "source_type": "user",
+            "source_file": f"{subject_id}_session_A.nwb",
+            "confidence": 1.0,
+        },
+    )
+    assert response1.status_code == 200
+
+    # Store conflicting observation for Rattus norvegicus
+    response2 = await kg_service_client.post(
+        "/api/v1/observations",
+        json={
+            "field_path": "subject.species",
+            "raw_value": "Rattus norvegicus",
+            "normalized_value": "Rattus norvegicus",
+            "ontology_term_id": "NCBITaxon:10116",
+            "source_type": "user",
+            "source_file": f"{subject_id}_session_B.nwb",
+            "confidence": 1.0,
+        },
+    )
+    assert response2.status_code == 200
+
+    # Call inference - should return no suggestion due to conflict
+    infer_response = await kg_service_client.post(
+        "/api/v1/infer",
+        json={
+            "field_path": "subject.species",
+            "source_file": f"{subject_id}_session_C.nwb",
+            "subject_id": subject_id,
+        },
+    )
+
+    assert infer_response.status_code == 200
+    data = infer_response.json()
+
+    assert data["has_suggestion"] is False
+    assert data["confidence"] == 0.0
+    assert "Insufficient evidence" in data["reasoning"]
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_infer_species_excludes_target_file(kg_service_client):
+    """Test that inference excludes observations from target file.
+
+    Ensures we don't use the current file's data to infer for itself.
+    """
+    subject_id = "subject_phase4_005"
+
+    # Store observation in target file
+    response1 = await kg_service_client.post(
+        "/api/v1/observations",
+        json={
+            "field_path": "subject.species",
+            "raw_value": "Mus musculus",
+            "normalized_value": "Mus musculus",
+            "ontology_term_id": "NCBITaxon:10090",
+            "source_type": "user",
+            "source_file": f"{subject_id}_session_TARGET.nwb",
+            "confidence": 1.0,
+        },
+    )
+    assert response1.status_code == 200
+
+    # Call inference for the same file - should have insufficient evidence
+    infer_response = await kg_service_client.post(
+        "/api/v1/infer",
+        json={
+            "field_path": "subject.species",
+            "source_file": f"{subject_id}_session_TARGET.nwb",
+            "subject_id": subject_id,
+        },
+    )
+
+    assert infer_response.status_code == 200
+    data = infer_response.json()
+
+    # Should have no suggestion because target file is excluded
+    assert data["has_suggestion"] is False
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_infer_unsupported_field(kg_service_client):
+    """Test inference for unsupported field path.
+
+    Currently only subject.species is supported.
+    """
+    subject_id = "subject_phase4_006"
+
+    infer_response = await kg_service_client.post(
+        "/api/v1/infer",
+        json={
+            "field_path": "subject.age",
+            "source_file": f"{subject_id}_session_A.nwb",
+            "subject_id": subject_id,
+        },
+    )
+
+    assert infer_response.status_code == 200
+    data = infer_response.json()
+
+    assert data["has_suggestion"] is False
+    assert data["confidence"] == 0.0
+    assert "not supported" in data["reasoning"]
+    assert "subject.age" in data["reasoning"]
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_infer_species_from_inferred_observations(kg_service_client):
+    """Test inference works with observations that were themselves inferred.
+
+    This tests the full loop where inference results can be stored
+    as observations and used for future inferences.
+    """
+    subject_id = "subject_phase4_007"
+
+    # Store observations marked as "inferred"
+    for session in ["A", "B"]:
+        response = await kg_service_client.post(
+            "/api/v1/observations",
+            json={
+                "field_path": "subject.species",
+                "raw_value": "Mus musculus",
+                "normalized_value": "Mus musculus",
+                "ontology_term_id": "NCBITaxon:10090",
+                "source_type": "inferred",
+                "source_file": f"{subject_id}_session_{session}.nwb",
+                "confidence": 0.8,
+                "provenance_json": {"inference_rule": "species_consistency"},
+            },
+        )
+        assert response.status_code == 200
+
+    # Infer for new session - should work with inferred observations
+    infer_response = await kg_service_client.post(
+        "/api/v1/infer",
+        json={
+            "field_path": "subject.species",
+            "source_file": f"{subject_id}_session_C.nwb",
+            "subject_id": subject_id,
+        },
+    )
+
+    assert infer_response.status_code == 200
+    data = infer_response.json()
+
+    assert data["has_suggestion"] is True
+    assert data["suggested_value"] == "Mus musculus"
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_infer_species_multiple_subjects_isolation(kg_service_client):
+    """Test that inference correctly isolates observations by subject.
+
+    Subject A and Subject B should not influence each other's inferences.
+    """
+    subject_a = "subject_phase4_008a"
+    subject_b = "subject_phase4_008b"
+
+    # Store observations for Subject A (Mus musculus)
+    for session in ["A", "B"]:
+        response = await kg_service_client.post(
+            "/api/v1/observations",
+            json={
+                "field_path": "subject.species",
+                "raw_value": "Mus musculus",
+                "normalized_value": "Mus musculus",
+                "ontology_term_id": "NCBITaxon:10090",
+                "source_type": "user",
+                "source_file": f"{subject_a}_session_{session}.nwb",
+                "confidence": 1.0,
+            },
+        )
+        assert response.status_code == 200
+
+    # Store observations for Subject B (Rattus norvegicus)
+    for session in ["A", "B"]:
+        response = await kg_service_client.post(
+            "/api/v1/observations",
+            json={
+                "field_path": "subject.species",
+                "raw_value": "Rattus norvegicus",
+                "normalized_value": "Rattus norvegicus",
+                "ontology_term_id": "NCBITaxon:10116",
+                "source_type": "user",
+                "source_file": f"{subject_b}_session_{session}.nwb",
+                "confidence": 1.0,
+            },
+        )
+        assert response.status_code == 200
+
+    # Infer for Subject A - should get Mus musculus
+    infer_a = await kg_service_client.post(
+        "/api/v1/infer",
+        json={
+            "field_path": "subject.species",
+            "source_file": f"{subject_a}_session_C.nwb",
+            "subject_id": subject_a,
+        },
+    )
+    assert infer_a.status_code == 200
+    data_a = infer_a.json()
+    assert data_a["suggested_value"] == "Mus musculus"
+
+    # Infer for Subject B - should get Rattus norvegicus
+    infer_b = await kg_service_client.post(
+        "/api/v1/infer",
+        json={
+            "field_path": "subject.species",
+            "source_file": f"{subject_b}_session_C.nwb",
+            "subject_id": subject_b,
+        },
+    )
+    assert infer_b.status_code == 200
+    data_b = infer_b.json()
+    assert data_b["suggested_value"] == "Rattus norvegicus"
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_infer_with_inactive_observations(kg_service_client):
+    """Test that inference only uses active observations.
+
+    Inactive observations should be excluded from inference.
+    """
+    subject_id = "subject_phase4_009"
+
+    # Store 2 active observations
+    for session in ["A", "B"]:
+        response = await kg_service_client.post(
+            "/api/v1/observations",
+            json={
+                "field_path": "subject.species",
+                "raw_value": "Mus musculus",
+                "normalized_value": "Mus musculus",
+                "ontology_term_id": "NCBITaxon:10090",
+                "source_type": "user",
+                "source_file": f"{subject_id}_session_{session}.nwb",
+                "confidence": 1.0,
+            },
+        )
+        assert response.status_code == 200
+
+    # Infer - should work
+    infer_response = await kg_service_client.post(
+        "/api/v1/infer",
+        json={
+            "field_path": "subject.species",
+            "source_file": f"{subject_id}_session_C.nwb",
+            "subject_id": subject_id,
+        },
+    )
+    assert infer_response.status_code == 200
+    data = infer_response.json()
+    assert data["has_suggestion"] is True
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+async def test_full_inference_workflow(kg_service_client):
+    """Test complete inference workflow: normalize -> observe -> infer.
+
+    This tests the integration of all phases working together.
+    """
+    subject_id = "subject_phase4_010"
+
+    # Step 1: Normalize species values
+    normalize_response = await kg_service_client.post(
+        "/api/v1/normalize",
+        json={
+            "field_path": "subject.species",
+            "value": "mouse",
+        },
+    )
+    assert normalize_response.status_code == 200
+    norm_data = normalize_response.json()
+
+    # Step 2: Store normalized observations for two sessions
+    for session in ["A", "B"]:
+        observe_response = await kg_service_client.post(
+            "/api/v1/observations",
+            json={
+                "field_path": "subject.species",
+                "raw_value": "mouse",
+                "normalized_value": norm_data["normalized_value"],
+                "ontology_term_id": norm_data["ontology_term_id"],
+                "source_type": "user",
+                "source_file": f"{subject_id}_session_{session}.nwb",
+                "confidence": norm_data["confidence"],
+            },
+        )
+        assert observe_response.status_code == 200
+
+    # Step 3: Infer species for new session
+    infer_response = await kg_service_client.post(
+        "/api/v1/infer",
+        json={
+            "field_path": "subject.species",
+            "source_file": f"{subject_id}_session_C.nwb",
+            "subject_id": subject_id,
+        },
+    )
+    assert infer_response.status_code == 200
+    infer_data = infer_response.json()
+
+    # Step 4: Verify inference result
+    assert infer_data["has_suggestion"] is True
+    assert infer_data["suggested_value"] == "Mus musculus"
+    assert infer_data["ontology_term_id"] == "NCBITaxon:10090"
+    assert infer_data["confidence"] == 0.8
+    assert infer_data["requires_confirmation"] is True
+
+    # Step 5: Store inferred observation (completing the loop)
+    final_observe_response = await kg_service_client.post(
+        "/api/v1/observations",
+        json={
+            "field_path": "subject.species",
+            "raw_value": infer_data["suggested_value"],
+            "normalized_value": infer_data["suggested_value"],
+            "ontology_term_id": infer_data["ontology_term_id"],
+            "source_type": "inferred",
+            "source_file": f"{subject_id}_session_C.nwb",
+            "confidence": infer_data["confidence"],
+            "provenance_json": {
+                "inference_rule": "species_consistency",
+                "reasoning": infer_data["reasoning"],
+            },
+        },
+    )
+    assert final_observe_response.status_code == 200


### PR DESCRIPTION
Add intelligent metadata inference capabilities to kg_service:

API Layer:
- Add infer.py endpoint for metadata inference requests
- Register inference routes in main.py

Service Layer:
- Add inference_engine.py for KG-based metadata inference
- Uses ontology terms and schema fields for intelligent suggestions

Test Coverage:
- Unit tests for inference API endpoint
- Unit tests for inference engine service
- Phase 4 integration tests for end-to-end inference workflow